### PR TITLE
Add Jest setup and QR scanner test

### DIFF
--- a/__tests__/qrScanner.test.js
+++ b/__tests__/qrScanner.test.js
@@ -1,0 +1,58 @@
+import { jest } from '@jest/globals';
+
+// Helper to load the script after setting up DOM
+function loadQRScript() {
+  return import('../test.js');
+}
+
+describe('startQRScanner', () => {
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <div id="qrScannerUI" style="display:none">
+        <p></p>
+        <video id="qrVideoFeed"></video>
+        <canvas id="qrCanvas"></canvas>
+      </div>
+    `;
+
+    const canvas = document.getElementById('qrCanvas');
+    canvas.getContext = jest.fn().mockReturnValue({
+      drawImage: jest.fn(),
+      getImageData: jest.fn().mockReturnValue({ data: [] })
+    });
+
+    // Mock global objects used by startQRScanner
+    global.navigator.mediaDevices = {
+      getUserMedia: jest.fn(() => Promise.resolve({ getTracks: () => [] }))
+    };
+    global.requestAnimationFrame = jest.fn();
+    global.jsQR = jest.fn();
+    global.UIManager = { showARStatusMessage: jest.fn() };
+
+    // Load script and dispatch DOMContentLoaded so startQRScanner is attached to window
+    await loadQRScript();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    // Stop automatic scanner started during load
+    if (window.stopQRScanner) {
+      window.stopQRScanner();
+    }
+  });
+
+  test('video element receives stream and UI becomes visible', async () => {
+    const video = document.getElementById('qrVideoFeed');
+    const ui = document.getElementById('qrScannerUI');
+
+    await window.startQRScanner();
+
+    // Resolve getUserMedia promise
+    await Promise.resolve();
+
+    // Trigger the metadata loaded callback
+    video.videoWidth = 640;
+    video.videoHeight = 480;
+    video.onloadedmetadata();
+
+    expect(video.srcObject).toBeDefined();
+    expect(ui.style.display).toBe('flex');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "prototipo_progetto",
+  "version": "1.0.0",
+  "description": "Prototype project with AR features",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "jsdom": "^22.1.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -88,6 +88,9 @@ window.addEventListener("DOMContentLoaded", () => {
       });
   }
 
+  // Expose for testing
+  window.startQRScanner = startQRScanner;
+
   function stopQRScanner() {
     console.log("Stopping QR Scanner...");
     if (currentQRScanRequest) {
@@ -105,6 +108,9 @@ window.addEventListener("DOMContentLoaded", () => {
     }
     console.log("QR Scanner stopped, UI hidden.");
   }
+
+  // Expose for testing
+  window.stopQRScanner = stopQRScanner;
 
   function scanQRCode() {
     if (qrVideoFeed.readyState === qrVideoFeed.HAVE_ENOUGH_DATA) {


### PR DESCRIPTION
## Summary
- configure Jest with jsdom
- expose `startQRScanner` and `stopQRScanner` on `window`
- add unit test for `startQRScanner`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449d93089083208b20677d168d4040