### PR TITLE
Enable AR session via 'Vedi in AR' button

### DIFF
--- a/UIManager.js
+++ b/UIManager.js
@@ -106,22 +106,44 @@ export const UIManager = {
         this.setSelectedModelUrl(itemFile);
         console.log(".showAR button clicked, model URL set to:", itemFile);
 
-        if (document.body.classList.contains("ar-active")) {
+        const xrSession = window.WebXRManager?.getXRSession?.();
+        if (xrSession) {
           if (
             window.WebXRManager &&
             typeof window.WebXRManager.hotSwapPlacedModel === "function"
           ) {
-            // itemFile is just the filename, e.g., "Cibo.glb"
-            // WebXRManager.hotSwapPlacedModel will prepend "./asset/"
             window.WebXRManager.hotSwapPlacedModel(itemFile);
           } else {
             console.error(
               "WebXRManager.hotSwapPlacedModel not found while in AR mode."
             );
           }
+        } else {
+          const startBtn = document.getElementById("startXRButton");
+          if (
+            window.WebXRManager &&
+            startBtn &&
+            startBtn.style.display === "block"
+          ) {
+            if (
+              typeof window.WebXRManager.placeModelWhenSurfaceFound ===
+              "function"
+            ) {
+              window.WebXRManager.placeModelWhenSurfaceFound(
+                "./asset/" + itemFile
+              );
+            }
+            window.WebXRManager.activateXR();
+          } else {
+            console.warn("AR session not ready. Scan QR code first.");
+            if (typeof this.showARStatusMessage === "function") {
+              this.showARStatusMessage(
+                "Scansiona il QR code prima di avviare l'AR.",
+                3000
+              );
+            }
+          }
         }
-        // If not in AR mode, simply selecting the model URL is enough.
-        // The normal flow (QR scan -> Start AR -> Tap to place) will use the new URL.
       }
     });
 

--- a/WebXRManager.js
+++ b/WebXRManager.js
@@ -9,6 +9,7 @@ let camera = null; // This will be the Three.js camera from app.js
 let hitTestSource = null;
 let reticle = null;
 let currentModel = null; // To store the currently placed model
+let pendingModelUrl = null; // Store model to place when surface is detected
 const gltfLoader = new GLTFLoader(); // Instantiate GLTFLoader
 const raycaster = new THREE.Raycaster(); // For interaction raycasting
 let xrController = null; // Represents the primary input (e.g., screen tap)
@@ -354,6 +355,11 @@ const WebXRManager = {
             );
             reticleHasShownSurfaceMessage = true;
           }
+
+          if (pendingModelUrl) {
+            this.placeModel(pendingModelUrl, reticle.matrix);
+            pendingModelUrl = null;
+          }
         }
       } else {
         if (reticle) {
@@ -452,6 +458,10 @@ const WebXRManager = {
         console.error("Error loading GLTF model in WebXRManager:", error);
       }
     );
+  },
+
+  placeModelWhenSurfaceFound(modelUrl) {
+    pendingModelUrl = modelUrl;
   },
 
   clearPlacedModelAndReselectSurface() {


### PR DESCRIPTION
## Summary
- start AR session when the user selects **Vedi in AR**
- automatically place selected model when surface is detected

## Testing
- `node --check ARController.js UIManager.js WebXRManager.js DragController.js RotationController.js app.js test.js`

------
https://chatgpt.com/codex/tasks/task_e_68449c2022ec8320933f32367ddc789a