### PR TITLE
Add 3D preview modal for dishes

### DIFF
--- a/3DPreview.js
+++ b/3DPreview.js
@@ -1,0 +1,79 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+let scene, camera, renderer, canvas, modal, loader;
+let model = null;
+let animId = null;
+
+function init() {
+  modal = document.getElementById('previewModal');
+  canvas = document.getElementById('previewCanvas');
+  if (!modal || !canvas) return;
+
+  scene = new THREE.Scene();
+  camera = new THREE.PerspectiveCamera(
+    45,
+    canvas.clientWidth / canvas.clientHeight,
+    0.1,
+    100
+  );
+  camera.position.set(0, 0, 2);
+
+  renderer = new THREE.WebGLRenderer({ canvas, alpha: true, antialias: true });
+  renderer.setPixelRatio(window.devicePixelRatio);
+  renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+
+  loader = new GLTFLoader();
+
+  const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
+  scene.add(light);
+
+  animate();
+}
+
+function animate() {
+  animId = requestAnimationFrame(animate);
+  if (model) {
+    model.rotation.y += 0.01;
+  }
+  renderer.render(scene, camera);
+}
+
+function resize() {
+  if (!renderer || !camera) return;
+  const width = canvas.clientWidth;
+  const height = canvas.clientHeight;
+  renderer.setSize(width, height);
+  camera.aspect = width / height;
+  camera.updateProjectionMatrix();
+}
+
+function show(modelUrl) {
+  if (!scene) init();
+  if (!scene) return;
+  if (model) {
+    scene.remove(model);
+    model = null;
+  }
+  loader.load(modelUrl, (gltf) => {
+    model = gltf.scene;
+    scene.add(model);
+  });
+  modal.style.display = 'flex';
+  resize();
+}
+
+function close() {
+  if (modal) modal.style.display = 'none';
+  if (model && scene) {
+    scene.remove(model);
+    model = null;
+  }
+}
+
+document.getElementById('closePreview')?.addEventListener('click', close);
+window.addEventListener('resize', resize);
+
+export const Preview3D = { show, close };
+window.Preview3D = Preview3D;
+

--- a/UIManager.js
+++ b/UIManager.js
@@ -149,6 +149,17 @@ export const UIManager = {
       }
     });
 
+    // Event listener for 3D preview buttons
+    document.addEventListener("click", (e) => {
+      const previewBtn = e.target.closest(".preview3D");
+      if (previewBtn && previewBtn.dataset.src) {
+        const itemFile = previewBtn.dataset.src;
+        if (window.Preview3D && typeof window.Preview3D.show === "function") {
+          window.Preview3D.show(`./asset/${itemFile}`);
+        }
+      }
+    });
+
     // Setup Auto-Rotate Button Listener
     const autoRotateButton = document.getElementById("autoRotateBtn");
     if (autoRotateButton && rotationControllerRef) {
@@ -267,6 +278,7 @@ export const UIManager = {
         <img src="${i.img}" alt="${i.name}">
         <h4>${i.name} – €${i.price.toFixed(2)}</h4>
         <p>${i.desc}</p>
+        <button class="preview3D" data-src="${i.file}">Anteprima 3D</button>
         <button class="showAR" data-src="${i.file}">Vedi in AR</button>
         <button class="addCart" data-src="${i.file}">Aggiungi</button>
       </div>`;

--- a/index.html
+++ b/index.html
@@ -156,6 +156,7 @@
     <!-- ===== APP LOGIC ============================================= -->
     <!-- Ensure app.js is loaded as a module if it uses ES6 imports -->
     <script src="test.js"></script>
+    <script type="module" src="3DPreview.js"></script>
     <!-- Re-enable test.js for QR scanning logic -->
 
     <!-- ===== AR STATUS MESSAGE UI =================================== -->
@@ -203,5 +204,11 @@
     <button id="arReselectSurfaceBtn" style="display: none">
       Reselect Surface
     </button>
+
+    <!-- 3D PREVIEW MODAL -->
+    <div id="previewModal" style="display:none; position: fixed; top:0; left:0; width:100%; height:100%; background: rgba(0,0,0,0.8); justify-content:center; align-items:center; z-index:3000;">
+      <button id="closePreview" class="closeBtn" style="position:absolute; top:10px; right:10px;">✕</button>
+      <canvas id="previewCanvas" style="width:80%; height:80%; max-width:400px;"></canvas>
+    </div>
   </body>
 </html>

--- a/test.css
+++ b/test.css
@@ -527,3 +527,33 @@ body:not(.sidebar-closed) #sidebarToggle {
   padding: 6px 12px;
   border-radius: 6px;
 }
+
+/* === 3D Preview Modal === */
+#previewModal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  justify-content: center;
+  align-items: center;
+  z-index: 3000;
+}
+
+#previewCanvas {
+  width: 80%;
+  height: 80%;
+  max-width: 400px;
+}
+
+#closePreview {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: transparent;
+  color: #fff;
+  border: none;
+  font-size: 1.5em;
+}


### PR DESCRIPTION
## Summary
- add modal for 3D preview and load it in `index.html`
- style modal in CSS
- allow UI to open 3D preview from menu cards
- implement `Preview3D` module to render GLB files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685042f24f48832092621c44afffd303